### PR TITLE
Add test for thread interruption during array read operation

### DIFF
--- a/src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java
+++ b/src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java
@@ -1882,6 +1882,40 @@ public class StreamBufferTest {
         assertThat("IOException should be thrown wrapping InterruptedException",
                 caught[0] instanceof IOException, is(true));
     }
+
+    @Test(timeout = 5000)
+    public void read_arrayThreadInterruptedWhileWaitingForSecondByte_throwsIOException() throws Exception {
+        // arrange
+        final StreamBuffer sb = new StreamBuffer();
+        final InputStream is = sb.getInputStream();
+        final OutputStream os = sb.getOutputStream();
+        final Semaphore started = new Semaphore(0);
+        final Throwable[] caught = new Throwable[1];
+
+        // write exactly 1 byte so the internal read() at the start of read(b,off,len)
+        // succeeds immediately, then tryWaitForEnoughBytes blocks waiting for the second byte
+        os.write(42);
+
+        Thread reader = new Thread(() -> {
+            try {
+                started.release();
+                is.read(new byte[2], 0, 2);
+            } catch (IOException e) {
+                caught[0] = e;
+            }
+        });
+
+        // act
+        reader.start();
+        started.acquire(); // wait for thread to start
+        Thread.sleep(500); // let it block inside tryWaitForEnoughBytes
+        reader.interrupt();
+        reader.join();
+
+        // assert
+        assertThat("IOException should be thrown wrapping InterruptedException",
+                caught[0] instanceof IOException, is(true));
+    }
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="correctOffsetAndLengthToRead empty array">


### PR DESCRIPTION
## Summary
Added a new test case to verify that thread interruption is properly handled when a read operation on an array is blocked waiting for additional bytes.

## Key Changes
- Added `read_arrayThreadInterruptedWhileWaitingForSecondByte_throwsIOException()` test method to `StreamBufferTest`
- Test verifies that an `IOException` wrapping `InterruptedException` is thrown when a thread is interrupted while blocked in `read(byte[], int, int)` waiting for the second byte
- Test writes exactly 1 byte to allow the initial read to succeed, then blocks on `tryWaitForEnoughBytes` for the second byte before interrupting the reader thread

## Implementation Details
- Uses a `Semaphore` to synchronize thread startup and ensure the reader thread is blocked before interruption
- Includes a 500ms sleep to allow the reader thread to block inside `tryWaitForEnoughBytes`
- Test has a 5-second timeout to prevent hanging
- Complements the existing `read_threadInterrupted_throwsIOException()` test by covering the array read variant

https://claude.ai/code/session_01MigLxLZ61SkZeLAejJBzCq