### PR TITLE
Update Gradle StreamByteBuffer reference to v8.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It is also not recommended to use both ends of a pipe from a single thread, as t
 
 ### Similar Solutions
 
-- [Gradle: StreamByteBuffer](https://github.com/gradle/gradle/blob/master/subprojects/base-services/src/main/java/org/gradle/internal/io/StreamByteBuffer.java)
+- [Gradle: StreamByteBuffer](https://github.com/gradle/gradle/blob/v8.4.0/subprojects/base-services/src/main/java/org/gradle/internal/io/StreamByteBuffer.java)
 
 ## Features
 


### PR DESCRIPTION
## Summary
Updated the documentation link to the Gradle StreamByteBuffer implementation to point to a specific version tag instead of the master branch.

## Changes
- Updated the GitHub link in the "Similar Solutions" section of README.md to reference the `v8.4.0` tag instead of the `master` branch
- This ensures the documentation points to a stable, versioned reference rather than a moving target

## Details
This change improves documentation stability by linking to a specific Gradle release version (v8.4.0) rather than the master branch, which can change over time. This makes the reference more reliable for users reviewing similar solutions.

https://claude.ai/code/session_01KTaBj2S3VwiZ6NpfUWYvg1