### PR TITLE
Update Gradle StreamByteBuffer reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It is also not recommended to use both ends of a pipe from a single thread, as t
 
 ### Similar Solutions
 
-- [Gradle: StreamByteBuffer](https://github.com/gradle/gradle/blob/v8.4.0/subprojects/base-services/src/main/java/org/gradle/internal/io/StreamByteBuffer.java)
+- [Gradle: StreamByteBuffer](https://github.com/gradle/gradle/blob/master/platforms/core-runtime/io/src/main/java/org/gradle/internal/io/StreamByteBuffer.java)
 
 ## Features
 


### PR DESCRIPTION
## Summary
Updated the documentation link to the Gradle StreamByteBuffer implementation to point to the current repository structure.

## Changes
- Updated the GitHub link from the versioned tag (`v8.4.0`) to the `master` branch
- Updated the file path to reflect the current project structure (`platforms/core-runtime/io/src/main/java/org/gradle/internal/io/StreamByteBuffer.java`)

## Details
The Gradle repository has reorganized its directory structure since version 8.4.0. This change ensures the "Similar Solutions" reference in the README points to the current location of the StreamByteBuffer implementation on the master branch, making it easier for users to review the referenced implementation.

https://claude.ai/code/session_013azxnoHZhqUhtdh5Q8RvCz