### PR TITLE
Add tests for StreamBuffer edge cases and boundary conditions

### DIFF
--- a/src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java
+++ b/src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java
@@ -2154,4 +2154,40 @@ public class StreamBufferTest {
         assertThat(result, is(0));
     }
     // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="isTrimShouldBeExecuted zero boundary">
+    @Test
+    public void getBufferSize_maxBufferElementsZeroWithMultipleEntries_noTrimExecuted() throws IOException {
+        // arrange
+        StreamBuffer sb = new StreamBuffer();
+        sb.setMaxBufferElements(0);
+
+        // act
+        sb.getOutputStream().write(new byte[]{1});
+        sb.getOutputStream().write(new byte[]{2});
+        sb.getOutputStream().write(new byte[]{3});
+
+        // assert
+        assertThat(sb.getBufferSize(), is(3));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="tryWaitForEnoughBytes closed stream return">
+    @Test
+    public void read_closedStreamWithTwoBytes_readArrayReturnsBothBytes() throws IOException {
+        // arrange
+        StreamBuffer sb = new StreamBuffer();
+        sb.getOutputStream().write(new byte[]{10, 20});
+        sb.close();
+
+        // act
+        byte[] dest = new byte[4];
+        int bytesRead = sb.getInputStream().read(dest, 0, 4);
+
+        // assert
+        assertThat(bytesRead, is(2));
+        assertThat(dest[0], is((byte) 10));
+        assertThat(dest[1], is((byte) 20));
+    }
+    // </editor-fold>
 }


### PR DESCRIPTION
## Summary
This PR adds two new test cases to the StreamBuffer test suite to improve coverage of edge cases and boundary conditions.

## Key Changes
- **Test for zero maxBufferElements boundary**: Added `getBufferSize_maxBufferElementsZeroWithMultipleEntries_noTrimExecuted()` to verify that when `maxBufferElements` is set to 0, trim operations are not executed and multiple write operations accumulate correctly in the buffer.

- **Test for reading from closed stream**: Added `read_closedStreamWithTwoBytes_readArrayReturnsBothBytes()` to verify that reading from a closed StreamBuffer with buffered data correctly returns all available bytes and properly sets the return value to the number of bytes read.

## Notable Details
Both tests follow the existing AAA (Arrange-Act-Assert) pattern used throughout the test suite and are properly organized with editor-fold markers for maintainability.

https://claude.ai/code/session_01XBopwez89Y6Yk2hyNbpjg5