### PR TITLE
Register internal signalModification semaphore via addSignal in constructor

### DIFF
--- a/src/main/java/net/ladenthin/streambuffer/StreamBuffer.java
+++ b/src/main/java/net/ladenthin/streambuffer/StreamBuffer.java
@@ -119,6 +119,7 @@ public class StreamBuffer implements Closeable {
      * Construct a new {@link StreamBuffer}.
      */
     public StreamBuffer() {
+        signals.add(signalModification);
     }
 
     /**
@@ -242,11 +243,7 @@ public class StreamBuffer implements Closeable {
      * signals a modification. It could be a write on the stream or a close.
      */
     private void signalModification() {
-        // hold up the permits to a maximum of one
-        if (signalModification.availablePermits() == 0) {
-            signalModification.release();
-        }
-        // release all registered external signals using the same max 1 permit pattern
+        // release all registered signals (including the internal one) using the max 1 permit pattern
         for (Semaphore signal : signals) {
             if (signal.availablePermits() == 0) {
                 signal.release();


### PR DESCRIPTION
The internal signalModification semaphore uses the same "max 1 permit" pattern as external signals. By registering it in the signals list during construction, the signalModification() method reduces to a single loop over all signals, eliminating the duplicated release block.

The semaphore is private final, so no external code can remove it via removeSignal() (Semaphore uses reference equality).

https://claude.ai/code/session_01WrBf5Z6n3zFoPvGdTDU5Xs