### PR TITLE
Enhance Codecov integration with token and test results upload

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,8 +34,15 @@ jobs:
         if: matrix.java-version == '8'
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: target/site/jacoco/jacoco.xml
         continue-on-error: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   mutation-testing:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Travis build status](https://travis-ci.org/bernardladenthin/streambuffer.svg)](https://travis-ci.org/bernardladenthin/streambuffer)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.ladenthin/streambuffer/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.ladenthin/streambuffer)
 [![Coverage Status](https://coveralls.io/repos/github/bernardladenthin/streambuffer/badge.svg)](https://coveralls.io/github/bernardladenthin/streambuffer)
-[![Codecov](https://codecov.io/github/bernardladenthin/streambuffer/coverage.png)](https://codecov.io/gh/bernardladenthin/streambuffer)
+[![codecov](https://codecov.io/gh/bernardladenthin/streambuffer/graph/badge.svg?token=BIO6krrehu)](https://codecov.io/gh/bernardladenthin/streambuffer)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5453/badge.svg)](https://scan.coverity.com/projects/5453)
 [![Known Vulnerabilities](https://snyk.io/test/github/bernardladenthin/streambuffer/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/bernardladenthin/streambuffer?targetFile=pom.xml)
 [![Code Quality: Java](https://img.shields.io/lgtm/grade/java/g/bernardladenthin/streambuffer.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/bernardladenthin/streambuffer/context:java)


### PR DESCRIPTION
## Summary
This PR improves the Codecov integration in the CI/CD pipeline by adding explicit token authentication and enabling test results upload to Codecov.

## Key Changes
- **Maven workflow**: Added `CODECOV_TOKEN` secret to the existing codecov-action step for explicit authentication
- **Maven workflow**: Added new step to upload test results to Codecov using `codecov/test-results-action@v1`, which runs regardless of previous step outcomes
- **README**: Updated Codecov badge URL to use the new badge format with token parameter for better tracking and visibility

## Implementation Details
- The test results upload step uses `if: ${{ !cancelled() }}` to ensure it runs even if previous steps fail, improving test visibility in Codecov
- Both Codecov actions now use the `CODECOV_TOKEN` secret for authenticated requests, which is more reliable than relying on GitHub context alone
- The badge update in README reflects the current Codecov badge format and includes the repository token for direct access

https://claude.ai/code/session_018e7Dax9ye4wXhF6MkKzrQ2