### PR TITLE
Add CI/CD pipeline for snapshot builds and GitHub Packages publishing

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,75 @@
+name: Build, Test and Publish Snapshot
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  # ---------------------------------------------------------------------------
+  # Build and test
+  # ---------------------------------------------------------------------------
+
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -s .mvn/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+      - name: Upload JARs
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-jars
+          path: target/*.jar
+
+  # ---------------------------------------------------------------------------
+  # Publish snapshot — only on push to master
+  # ---------------------------------------------------------------------------
+
+  publish-snapshot:
+    name: Publish Snapshot to GitHub Releases and GitHub Packages
+    needs: [ build ]
+    if: github.event_name == 'push' && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: plugin-jars
+          path: snapshot-jars/
+      - name: Publish rolling snapshot release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release delete snapshot --yes --cleanup-tag || true
+          gh release create snapshot snapshot-jars/*.jar \
+            --title "Snapshot Build" \
+            --notes "Snapshot from ${{ github.sha }} — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --prerelease \
+            --target ${{ github.sha }}
+      - name: Set up Maven for GitHub Packages
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - name: Publish to GitHub Packages
+        run: |
+          mvn --batch-mode deploy -s .mvn/settings.xml -Dmaven.test.skip=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${env.GITHUB_ACTOR}</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,13 @@
         <developerConnection>scm:git:https://github.com/bernardladenthin/streambuffer</developerConnection>
         <url>https://github.com/bernardladenthin/streambuffer</url>
     </scm>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/bernardladenthin/streambuffer</url>
+        </repository>
+    </distributionManagement>
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
This PR introduces a complete CI/CD workflow that automatically builds, tests, and publishes snapshot releases to GitHub Releases and GitHub Packages on every push to the master branch.

## Key Changes
- **GitHub Actions Workflow** (`.github/workflows/snapshot.yml`): Added a new workflow that:
  - Builds and tests the project on every push to master and all pull requests
  - Publishes snapshot artifacts to GitHub Releases as a rolling "snapshot" release
  - Deploys snapshot packages to GitHub Packages Maven repository
  - Uses Java 17 with Zulu distribution and Maven caching for faster builds

- **Maven Configuration** (`.mvn/settings.xml`): Added Maven settings file to configure GitHub Packages authentication using GitHub token credentials

- **POM Configuration** (`pom.xml`): Added `distributionManagement` section to specify GitHub Packages as the snapshot repository target

## Implementation Details
- The workflow runs on push to master, pull requests, and manual dispatch
- Build artifacts are uploaded and reused in the publish step to avoid rebuilding
- The snapshot release is marked as a prerelease and automatically replaces the previous snapshot
- Maven authentication is handled via environment variables (`GITHUB_TOKEN` and `GITHUB_ACTOR`)
- The publish step only executes on successful builds pushed to master

https://claude.ai/code/session_01ResEx8tuBxzY42xq1R9V9X