### PR TITLE
Add contents read permission to snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
Added explicit `contents: read` permission to the snapshot workflow's build job to follow GitHub Actions security best practices.

## Key Changes
- Added `permissions` block with `contents: read` to the build job in `.github/workflows/snapshot.yml`

## Implementation Details
This change implements the principle of least privilege by explicitly declaring the minimum required permissions for the workflow job. The `contents: read` permission allows the job to read repository contents (needed for the `actions/checkout@v4` step) while restricting other potentially unnecessary permissions by default.

https://claude.ai/code/session_018GqGrJWwE6Fhw9UPy6ViEv