### PR TITLE
Clean up old snapshot versions before publishing to GitHub Packages

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -69,6 +69,13 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
+      - name: Delete old snapshot versions from GitHub Packages
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: 'net.ladenthin.streambuffer'
+          package-type: 'maven'
+          min-versions-to-keep: 0
+        continue-on-error: true
       - name: Publish to GitHub Packages
         run: |
           mvn --batch-mode deploy -s .mvn/settings.xml -Dmaven.test.skip=true


### PR DESCRIPTION
## Summary
Added a step to the snapshot workflow that automatically deletes old snapshot versions from GitHub Packages before publishing new ones. This helps manage package storage and prevents accumulation of outdated snapshot builds.

## Key Changes
- Added `actions/delete-package-versions@v5` step to the snapshot workflow
- Configured to delete all old versions of the `net.ladenthin.streambuffer` Maven package (`min-versions-to-keep: 0`)
- Set `continue-on-error: true` to ensure the workflow continues even if the cleanup step fails
- Cleanup runs immediately before the publish step to ensure a clean state

## Implementation Details
The new step targets the GitHub Packages Maven registry and removes all previous snapshot versions before deploying the new snapshot, keeping the package registry clean and reducing storage overhead.

https://claude.ai/code/session_01BYbSQEhXmcXudk2kBwfnSQ