### PR TITLE
fix: delete entire package instead of versions to avoid last-version …

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -69,13 +69,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - name: Delete old snapshot versions from GitHub Packages
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: 'net.ladenthin.streambuffer'
-          package-type: 'maven'
-          min-versions-to-keep: 0
-        continue-on-error: true
+      - name: Delete snapshot package from GitHub Packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api --method DELETE /user/packages/maven/net.ladenthin.streambuffer || true
       - name: Publish to GitHub Packages
         run: |
           mvn --batch-mode deploy -s .mvn/settings.xml -Dmaven.test.skip=true


### PR DESCRIPTION
…error

actions/delete-package-versions cannot remove the last version of a package; the API requires deleting the package itself in that case. Switch to a direct gh api DELETE call which removes the whole package at once so mvn deploy always starts clean.