### PR TITLE
Add JMH throughput benchmarks for StreamBuffer

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -146,3 +146,14 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with: { name: pit-reports, path: target/pit-reports/ }
+      - name: Run JMH benchmarks
+        run: >
+          mvn --batch-mode exec:java
+          -Dexec.mainClass=org.openjdk.jmh.Main
+          -Dexec.classpathScope=test
+          -Dexec.args="StreamBufferThroughputBenchmark -wi 2 -i 3 -f 1 -rf json -rff target/jmh-results.json"
+          -Dmaven.javadoc.skip=true
+        continue-on-error: true
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with: { name: jmh-results, path: target/jmh-results.json }

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,18 @@
             <version>3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.37</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.37</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -177,6 +189,15 @@
                     </execution>
                 </executions>
             </plugin> -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                    <classpathScope>test</classpathScope>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>

--- a/src/test/java/net/ladenthin/streambuffer/benchmark/StreamBufferThroughputBenchmark.java
+++ b/src/test/java/net/ladenthin/streambuffer/benchmark/StreamBufferThroughputBenchmark.java
@@ -1,0 +1,131 @@
+// @formatter:off
+/**
+ * Copyright 2014 Bernard Ladenthin bernard.ladenthin@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+// @formatter:on
+package net.ladenthin.streambuffer.benchmark;
+
+import net.ladenthin.streambuffer.StreamBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Throughput benchmark for {@link StreamBuffer}.
+ *
+ * <p>Replaces the removed {@code testMemory()} test (Wolfgang Fahl, 2017) with a
+ * deterministic JMH measurement. Instead of asserting a GC-dependent memory
+ * threshold, this benchmark reports ops/sec and — when run with {@code -prof gc}
+ * — {@code gc.alloc.rate}, making memory pressure observable without being flaky.</p>
+ *
+ * <p>Run locally:</p>
+ * <pre>
+ * mvn test-compile exec:java \
+ *   -Dexec.mainClass=org.openjdk.jmh.Main \
+ *   -Dexec.classpathScope=test \
+ *   -Dexec.args="StreamBufferThroughputBenchmark -prof gc"
+ * </pre>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@Fork(1)
+public class StreamBufferThroughputBenchmark {
+
+    /** Block sizes: 128 B (small), 4 KB (typical), 40 KB (Wolfgang's original size: 10 * 2^12 bytes). */
+    @Param({"128", "4096", "40960"})
+    public int blockSize;
+
+    /** Whether {@link StreamBuffer#setSafeWrite(boolean)} is enabled (clones arrays on write). */
+    @Param({"false", "true"})
+    public boolean safeWrite;
+
+    private StreamBuffer sb;
+    private OutputStream os;
+    private InputStream is;
+    private byte[] writeBlock;
+    private byte[] readBlock;
+
+    @Setup(Level.Invocation)
+    public void setUp() throws IOException {
+        sb = new StreamBuffer();
+        sb.setSafeWrite(safeWrite);
+        os = sb.getOutputStream();
+        is = sb.getInputStream();
+        writeBlock = new byte[blockSize];
+        readBlock = new byte[blockSize];
+        for (int i = 0; i < blockSize; i++) {
+            writeBlock[i] = (byte) (i & 0xFF);
+        }
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDown() throws IOException {
+        sb.close();
+    }
+
+    /**
+     * Write one block then read it back in a loop.
+     *
+     * <p>Measures round-trip throughput. With {@code -prof gc} reveals allocation
+     * rate and GC pressure — the non-flaky replacement for Wolfgang's 64&nbsp;MB
+     * memory assertion.</p>
+     */
+    @Benchmark
+    public void writeReadRoundTrip(Blackhole bh) throws IOException {
+        os.write(writeBlock);
+        int totalRead = 0;
+        while (totalRead < blockSize) {
+            int n = is.read(readBlock, totalRead, blockSize - totalRead);
+            if (n < 0) {
+                break;
+            }
+            totalRead += n;
+        }
+        bh.consume(totalRead);
+    }
+
+    /**
+     * Write one block without reading.
+     *
+     * <p>Measures raw write-path throughput. With {@code -prof gc} shows whether
+     * {@code trim()} consolidation causes unexpected allocation spikes as the
+     * internal deque grows.</p>
+     */
+    @Benchmark
+    public void writeOnly(Blackhole bh) throws IOException {
+        os.write(writeBlock);
+        bh.consume(sb.getBufferElementCount());
+    }
+}


### PR DESCRIPTION
## Summary
Introduces JMH (Java Microbenchmark Harness) benchmarks for StreamBuffer to replace the removed flaky memory assertion test with deterministic performance measurements.

## Key Changes
- **New benchmark class**: `StreamBufferThroughputBenchmark` with two benchmark methods:
  - `writeReadRoundTrip()`: Measures round-trip throughput (write then read back)
  - `writeOnly()`: Measures raw write-path throughput to detect allocation spikes
  
- **Parameterized tests**: Benchmarks run across multiple configurations:
  - Block sizes: 128 B, 4 KB, 40 KB (original test size)
  - Safe write mode: enabled/disabled
  
- **Build integration**:
  - Added JMH dependencies (jmh-core, jmh-generator-annprocess) v1.37
  - Added exec-maven-plugin for running benchmarks via Maven
  - Added CI workflow step to run benchmarks and upload JSON results

## Notable Details
- Replaces Wolfgang Fahl's removed `testMemory()` test with observable metrics (ops/sec, gc.alloc.rate)
- Benchmarks are invocation-scoped to isolate each test run
- Includes documentation on running benchmarks locally with GC profiling
- CI runs with reduced iterations (2 warmup, 3 measurement) for faster feedback

https://claude.ai/code/session_01CnDbuGuThZaVUwfUo1b7kt