### PR TITLE
fix: re-enable JaCoCo and use JMH in-process mode (-f 0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,7 +151,7 @@ jobs:
           mvn --batch-mode exec:java
           -Dexec.mainClass=org.openjdk.jmh.Main
           -Dexec.classpathScope=test
-          -Dexec.args="StreamBufferThroughputBenchmark -wi 2 -i 3 -f 1 -rf json -rff target/jmh-results.json"
+          -Dexec.args="StreamBufferThroughputBenchmark -wi 2 -i 3 -f 0 -rf json -rff target/jmh-results.json"
           -Dmaven.javadoc.skip=true
         continue-on-error: true
       - uses: actions/upload-artifact@v7

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>5.0.0</version>
             </plugin> -->
-            <!-- <plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.14</version>
@@ -188,7 +188,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> -->
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary

- **JMH `ForkedMain` not found**: `exec:java` runs JMH inside Maven's own JVM; the forked child process does not inherit the test classpath so `org.openjdk.jmh.runner.ForkedMain` cannot be found. Switch to `-f 0` (no fork) so JMH runs all benchmarks in-process. Results are slightly less isolated but valid for informational CI benchmarks.
- **`jacoco-report` artifact missing**: JaCoCo plugin was commented out in `pom.xml`, so `mvn verify` never generated `target/site/jacoco/jacoco.xml`. The upload step silently skipped (`if-no-files-found: ignore`) and the `post-publish` download step failed with "Artifact not found" — Codecov and Coveralls received nothing. Uncomment the existing plugin block (`prepare-agent` + `report` at `test` phase) to restore coverage reporting.

## Test plan

- [ ] `mvn test` passes (269 tests) and `target/site/jacoco/jacoco.xml` is generated
- [ ] CI `test` job uploads `jacoco-report` artifact without error
- [ ] CI `post-publish` downloads artifact; Codecov and Coveralls steps receive actual data
- [ ] JMH step completes with benchmark scores in the log (no `ForkedMain` error)
- [ ] `jmh-results.json` artifact is non-empty with actual measurements

https://claude.ai/code/session_01CnDbuGuThZaVUwfUo1b7kt

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnDbuGuThZaVUwfUo1b7kt)_