### PR TITLE
Use GITHUB_TOKEN instead of COVERALLS_TOKEN in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           file: target/site/jacoco/jacoco.xml
           format: jacoco
         continue-on-error: true


### PR DESCRIPTION
## Summary
Updated the Coveralls GitHub Action configuration to use the built-in `GITHUB_TOKEN` secret instead of a custom `COVERALLS_TOKEN` secret.

## Changes
- Replaced `secrets.COVERALLS_TOKEN` with `secrets.GITHUB_TOKEN` in the Coveralls step of the publish workflow

## Details
This change simplifies the CI/CD configuration by leveraging GitHub's automatically-provided `GITHUB_TOKEN` secret, which is available in all workflows by default. This eliminates the need to maintain a separate custom token for Coveralls integration while maintaining the same functionality.

https://claude.ai/code/session_01N44axmNKwhiN551zbe8WEJ