### PR TITLE
Add start gate abort window to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,21 @@ permissions:
   contents: read
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Start gate — single cancellable abort window before the pipeline starts.
+  # The wait duration lives in the `startgate` GitHub Environment (Settings →
+  # Environments → startgate → Wait timer).
+  # ---------------------------------------------------------------------------
+  startgate:
+    name: Start gate (abort window)
+    runs-on: ubuntu-latest
+    environment: startgate
+    steps:
+      - run: echo "Start gate elapsed — proceeding with pipeline."
+
   build:
     name: Build
+    needs: startgate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Introduces a configurable abort window at the start of the publish workflow, allowing developers to cancel the pipeline before the build job begins.

## Changes

- **New `startgate` job**: Added a gating job that runs before the `build` job with a configurable wait duration
  - Configured via GitHub Environment (`startgate`) with a Wait timer setting
  - Provides a cancellation window before any pipeline work begins
  - Added `needs: startgate` dependency to the `build` job to enforce sequencing

## Implementation Details

The start gate is implemented as a minimal job that:
- Runs on `ubuntu-latest`
- Uses the `startgate` GitHub Environment to control the wait duration via Settings → Environments → startgate → Wait timer
- Outputs a confirmation message when the gate elapses
- Blocks downstream jobs (`build` and transitively all dependent jobs) until completion

This pattern allows teams to abort the publish pipeline during a grace period without consuming build resources.

https://claude.ai/code/session_01TGzxSDP2uzsGiJupDsNad1