### PR TITLE
docs: OpenSSF Best Practices passing-level artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- OpenSSF Best Practices badge added to README (project 12861).
+- `CONTRIBUTING.md` with build instructions, test policy, and PR workflow.
+- `SECURITY.md` with vulnerability reporting process and response SLA.
+- `CHANGELOG.md` (this file) seeded from existing git history.
+- Cancellable pipeline start-gate via a `startgate` GitHub Environment with configurable wait timer.
+
+### Changed
+- CI `publish.yml`: added `check-snapshot`/`check-tag` gate jobs to fix release routing.
+- CI `publish.yml`: `softprops/action-gh-release` bumped from v2 to v3.
+- CI `publish.yml`: `org.codehaus.mojo:exec-maven-plugin` bumped to 3.6.3.
+
+## [1.2.0] - 2026-05-11
+
+### Added
+- Statistics tracking: `getTotalBytesWritten()`, `getTotalBytesRead()`, `getMaxObservedBytes()` — user I/O only, excluding internal trim operations.
+- Configurable trim allocation size via `setMaxAllocationSize(long)` / `getMaxAllocationSize()`; trim may produce multiple smaller chunks when `availableBytes > maxAllocationSize`.
+- Trim observer signals: `addTrimStartSignal(Semaphore)`, `removeTrimStartSignal(Semaphore)`, `addTrimEndSignal(Semaphore)`, `removeTrimEndSignal(Semaphore)`.
+- `isTrimRunning()` volatile flag reflecting active trim execution.
+- `decideTrimExecution` pure function with comprehensive table-driven tests.
+- `getBufferElementCount()` synchronized method (preferred over legacy `getBufferSize()`).
+- JMH throughput benchmark (`StreamBufferThroughputBenchmark`) replacing the prior ad-hoc memory test.
+- CI: JARs are now attached to GitHub Releases on tag push.
+- CI: GitHub Packages snapshot pre-release updated on every push to `main`.
+- CI: unified `publish.yml` with Sonatype Central Portal publishing (replaced OSSRH).
+- CI: CodeQL workflow with `security-and-quality` query suite.
+- CI: Coveralls and Codecov coverage reporting.
+- CI: PIT mutation testing in the report job (100% mutation coverage threshold).
+- Claude Code review workflow (`claude-code-review.yml`).
+- Dependabot configuration for Maven and GitHub Actions dependencies.
+
+### Changed
+- Testing framework migrated from JUnit 4 (`DataProviderRunner`) to JUnit 5 (JUnit Jupiter) with `@Nested` and `@DisplayName` grouping.
+- Internal semaphore (`signalModification`) now registered via the public `addSignal` mechanism.
+- Listener/callback pattern replaced by signal/slot via external `Semaphore` objects.
+- `read()` conditional replaced with `Math.min` to eliminate equivalent mutation.
+- All Javadoc comments updated to use HTML entities for operators and Unicode symbols.
+- Distribution management migrated from OSSRH to Sonatype Central Publisher Portal.
+- GH Actions bumped to latest: `checkout@v6`, `setup-java@v5`, `upload-artifact@v7`, `download-artifact@v8`, `codecov-action@v6`, `codeql-action@v4`.
+- Maven plugins updated: JaCoCo 0.8.14, PIT 1.23.0, and others to latest stable.
+
+### Fixed
+- Race condition between `trim()` write-back and `close()` — `releaseTrimStartSignals()` moved inside `try-finally`.
+- `read(byte[], int, int)` over-read on closed stream — six edge-case tests added.
+- Coveralls authentication switched from deprecated token to `GITHUB_TOKEN`.
+- JaCoCo re-enabled and JMH run in in-process mode (`-f 0`) to fix CI flakiness.
+- CodeQL action bumped from v3 to v4 with explicit workflow permissions.
+
+[Unreleased]: https://github.com/bernardladenthin/streambuffer/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/bernardladenthin/streambuffer/releases/tag/v1.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to streambuffer
+
+Thank you for your interest in contributing to **streambuffer** — a single-class Java library that bridges `OutputStream` and `InputStream` through a dynamic, unbounded FIFO queue.
+
+## 1. How to Build and Run
+
+**Prerequisites:** Java 8+ (tests require Java 17+), Maven 3.3.9+
+
+```bash
+# Compile
+mvn compile
+
+# Run all tests with coverage
+mvn test
+
+# Build the JAR
+mvn package
+
+# Install to your local Maven repository (skip GPG signing)
+mvn install -Dgpg.skip=true
+
+# Run a single test
+mvn test -Dtest=StreamBufferTest#testSimpleRoundTrip
+
+# Run mutation tests (PIT)
+mvn org.pitest:pitest-maven:mutationCoverage
+```
+
+## 2. Filing Issues
+
+Please open a GitHub Issue at:
+
+**https://github.com/bernardladenthin/streambuffer/issues**
+
+Before opening a new issue, search existing issues to avoid duplicates. Include:
+
+- A minimal reproducible example (Java code snippet + observed vs. expected behaviour)
+- Java version and OS
+- streambuffer version (or commit SHA if building from source)
+
+## 3. Pull Request Workflow
+
+1. **Fork** the repository on GitHub.
+2. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feature/my-descriptive-name
+   ```
+3. **Make your changes** with tests (see [Test Policy](#5-test-policy) below).
+4. **Run the full test suite** locally before pushing:
+   ```bash
+   mvn verify
+   ```
+5. **Push** your branch to your fork and open a **Pull Request** against `bernardladenthin/streambuffer:main`.
+6. Address any review comments and push updates to the same branch.
+7. A maintainer will merge once the PR is approved and CI passes.
+
+Keep PRs focused: one logical change per PR makes review faster.
+
+## 4. Coding Standards
+
+- **Java version:** source and binary compatibility targets Java 8; tests may use Java 17 features.
+- **Encoding:** UTF-8 (enforced by `project.build.sourceEncoding` in `pom.xml`).
+- **Javadoc:** use HTML entities for operators and symbols — never bare Unicode in Javadoc comments. See [`CLAUDE.md`](CLAUDE.md) for the full entity table (`&lt;`, `&gt;`, `&#x2264;`, etc.).
+- **Thread safety:** all accesses to the internal `Deque` must remain guarded by `bufferLock`; state fields must remain `volatile`.
+- **Formatting:** follow the style of existing source files (consistent indentation, brace placement, etc.). No external formatter is currently enforced by the build, so match the surrounding code.
+
+## 5. Test Policy
+
+> Every new feature or behavior change MUST include automated tests. Pull requests that add or change functionality without corresponding tests will be asked to add tests before merge. Bug fixes SHOULD include a regression test.
+
+Tests live in `src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java` and use JUnit 4 with `DataProviderRunner`. Most behavioural tests are parameterized across three write strategies (`ByteArray`, `Int`, `ByteArrayWithParameter`). New tests should follow the same pattern where applicable.
+
+## 6. Communication Channels
+
+- **GitHub Issues:** https://github.com/bernardladenthin/streambuffer/issues — bug reports, feature requests, and general questions
+- **GitHub Discussions:** not currently enabled; use Issues for all communication
+
+## 7. License of Contributions
+
+By submitting a pull request you agree that your contributions will be licensed under the **Apache License, Version 2.0** — the same license that covers this project. See [`LICENSE-2.0.txt`](LICENSE-2.0.txt) for the full text.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor release of the current major version receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| 1.2.x (latest release) | Yes |
+| < 1.2 | No |
+
+Once a new minor or patch release is published, the previous release is no longer supported. Users are encouraged to upgrade promptly.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub Issues.**
+
+### Primary: GitHub Private Vulnerability Reporting
+
+Use GitHub's built-in private vulnerability reporting to disclose vulnerabilities confidentially:
+
+**https://github.com/bernardladenthin/streambuffer/security/advisories/new**
+
+This allows you to submit details privately. A maintainer will review the report and respond through the advisory thread.
+
+### Secondary: Maintainer Email
+
+If you are unable to use GitHub's private reporting, you may contact the maintainer directly at:
+
+**bernard.ladenthin@gmail.com**
+
+> **Note:** This email address is taken from the project's `pom.xml` developer record and has not been separately confirmed as a security contact. GitHub Private Vulnerability Reporting is the preferred channel.
+
+When reporting, please include:
+
+- A clear description of the vulnerability and its potential impact
+- Steps to reproduce (minimal Java code if applicable)
+- The streambuffer version(s) affected
+- Any suggested mitigation or fix
+
+## Response SLA
+
+We aim to acknowledge vulnerability reports within 14 days of receipt and to provide a remediation timeline within 30 days.
+
+## Disclosure Policy
+
+This project follows **coordinated disclosure**:
+
+1. The reporter submits the vulnerability privately.
+2. The maintainer investigates and develops a fix.
+3. A patched release is prepared and published.
+4. The vulnerability details remain under embargo until the fix is publicly released.
+5. A GitHub Security Advisory is published after the fix is available, crediting the reporter (unless they prefer to remain anonymous).
+
+We ask reporters to honour the embargo period and not disclose vulnerability details publicly until a fix has been released.


### PR DESCRIPTION
## Summary

Adds the three community-health files required for the OpenSSF Best Practices passing level badge:

- `CONTRIBUTING.md` — build/test commands, issue filing, PR workflow, coding standards, test policy, license of contributions
- `SECURITY.md` — supported versions, private vulnerability reporting, response SLA, disclosure policy
- `CHANGELOG.md` — seeded from git history in Keep a Changelog 1.1.0 + SemVer format

## OpenSSF Criteria Unlocked

| File | Criterion IDs |
|---|---|
| CONTRIBUTING.md | `interact`, `contribution`, `contribution_requirements`, `test_policy`, `tests_are_added`, `tests_documented_added` |
| SECURITY.md | `vulnerability_report_process`, `vulnerability_report_private`, `vulnerability_report_response` |
| CHANGELOG.md | `release_notes`, `release_notes_vulns` |

## Audit Findings

| Area | Finding |
|---|---|
| **Git tags** | No release tags exist in the repository. The 1.2.0 release is recorded only as a commit (`317398c`, 2026-05-11). The `[1.2.0]` compare URL in CHANGELOG.md references `v1.2.0` — a tag that should be created to make the link functional. |
| **Maintainer email (git log)** | `git log --format='%ae' -1` returns `noreply@anthropic.com` (a CI/bot commit). The canonical maintainer email `bernard.ladenthin@gmail.com` was taken from `pom.xml` developers and is used in SECURITY.md. |
| **Private Vulnerability Reporting** | `gh api` returned "unavailable" for `security_and_analysis.private_vulnerability_reporting.status` — the API field may require admin scope or the feature may not yet be enabled. Recommend verifying in Settings → Security → Private vulnerability reporting. |
| **CodeQL** | `codeql.yml` exists and runs on push/PR to `main` and weekly schedule with `security-and-quality` queries. **Criterion satisfied.** |
| **Tests in CI** | `publish.yml` runs `mvn verify` on JDK 17 and 21 on every push and PR. **Criterion satisfied.** |
| **Current version** | pom.xml is at `1.3.0-SNAPSHOT`. No git tag marks any release; tagging `v1.2.0` at commit `317398c` is recommended for traceability. |

## Test Plan

- [ ] Verify CONTRIBUTING.md renders correctly on GitHub (section headers, code blocks)
- [ ] Verify SECURITY.md private reporting link resolves to the repo's advisory form
- [ ] Verify CHANGELOG.md links at the bottom point to the correct compare URLs
- [ ] Confirm CI passes on this PR (build + test jobs in publish.yml)

https://claude.ai/code/session_01XUpsiwWio7dX379whH838C

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUpsiwWio7dX379whH838C)_