### PR TITLE
docs: OpenSSF Best Practices passing-level artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Release Process
+
+> Paste this prompt into a new Claude Code session, fill in the three placeholders, and send it to perform a release.
+
+```
+Release `{PROJECT}` to Maven Central.
+
+**Step 1 — Prepare the release (do immediately):**
+1. Read the current version from `pom.xml` on `main` — it will be `{VERSION}-SNAPSHOT`
+2. Strip `-SNAPSHOT` from `pom.xml` (→ `{VERSION}`)
+3. In `README.md`, update **both**:
+   - The release dependency example to `{VERSION}`
+   - The snapshot dependency example to `{VERSION}-SNAPSHOT` (it should already match, but verify)
+4. Commit both files directly to `main` (no pull request)
+
+**Step 2 — Wait for manual confirmation:**
+I will create the `v{VERSION}` tag and GitHub release manually — wait for me to confirm
+the release is published on Maven Central before proceeding.
+
+**Step 3 — Post-release snapshot bump (after my confirmation):**
+Bump **both** files on `main`:
+- `pom.xml` → `{NEXT_VERSION}-SNAPSHOT`
+- `README.md` snapshot dependency example → `{NEXT_VERSION}-SNAPSHOT`
+
+Commit both changes together directly to `main`.
+
+**Placeholders:**
+
+| Placeholder      | Value                                        |
+|------------------|----------------------------------------------|
+| `{PROJECT}`      | *(project name)*                             |
+| `{VERSION}`      | *(release version, e.g. `1.3.0`)*           |
+| `{NEXT_VERSION}` | *(next snapshot base, e.g. `1.3.1`)*        |
+```
+
+---
+
 ## [Unreleased]
 
 ### Added


### PR DESCRIPTION
## Summary

Adds the three files required to reach the OpenSSF Best Practices **passing** level, plus a reusable release process prompt template.

- `CONTRIBUTING.md` — build/run commands, issue filing, PR workflow, coding standards (Javadoc HTML entities, thread-safety rules), test policy, communication channels, license of contributions
- `SECURITY.md` — supported versions (1.2.x), private vulnerability reporting, 14/30-day response SLA, coordinated disclosure policy
- `CHANGELOG.md` — Keep a Changelog 1.1.0 format, seeded from existing tags (`[1.2.0]` and `[Unreleased]`), plus a **Release Process** section with a reusable AI-agent prompt template for Maven Central releases

## Criteria unlocked

| File | Criterion IDs |
|---|---|
| `CONTRIBUTING.md` | `interact`, `contribution`, `contribution_requirements`, `test_policy`, `tests_are_added`, `tests_documented_added` |
| `SECURITY.md` | `vulnerability_report_process`, `vulnerability_report_private`, `vulnerability_report_response` |
| `CHANGELOG.md` | `release_notes`, `release_notes_vulns` |

## Audit findings

- **No git tags** — `v1.2.0` tag should be pushed at commit `317398c` for CHANGELOG compare URLs to resolve
- **Maintainer email** — `bernard.ladenthin@gmail.com` sourced from `pom.xml`; please confirm before merge
- **Private Vulnerability Reporting** — status cannot be verified without admin scope; please enable in repo Settings → Security
- **CodeQL** — already active ✅
- **Tests in CI** — run on every push/PR across JDK 17 and 21 ✅

https://claude.ai/code/session_01XUpsiwWio7dX379whH838C

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUpsiwWio7dX379whH838C)_