### PR TITLE
Upgrade Java target to 21 and update JaCoCo to 0.8.15

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
-        with: { java-version: '17', distribution: temurin }
+        with: { java-version: '21', distribution: temurin }
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }
       - uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: temurin
           cache: maven
       - name: Build
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: ['17', '21']
+        java-version: ['21']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -60,7 +60,7 @@ jobs:
       - name: Test
         run: mvn --batch-mode verify -Dmaven.javadoc.skip=true
       - uses: actions/upload-artifact@v7
-        if: matrix.java-version == '17'
+        if: matrix.java-version == '21'
         with:
           name: jacoco-report
           path: target/site/jacoco/jacoco.xml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
-        with: { java-version: '17', distribution: temurin, cache: maven }
+        with: { java-version: '21', distribution: temurin, cache: maven }
       - uses: actions/download-artifact@v8
         with: { name: jacoco-report, path: target/site/jacoco/ }
         continue-on-error: true
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: temurin
           cache: maven
           server-id: central
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: temurin
           cache: maven
           server-id: central

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@ SPDX-License-Identifier: Apache-2.0
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
+                <version>0.8.15</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
## Summary

- Upgrade Java version from 17 to 21 across all CI workflows (publish, codeql)
- Remove Java 17 from the test matrix, keeping only Java 21
- Update JaCoCo Maven plugin from 0.8.14 to 0.8.15
- Update artifact upload condition to use Java 21 instead of 17

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01LsRLQoBtsgebZ7AwS1zAWS