### PR TITLE
Upgrade Java test version to 21 and improve snapshot publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,17 +141,51 @@ jobs:
       - name: Confirm tag ref
         run: echo "Confirmed on tag ${{ github.ref }}"
 
-  github-snapshot:
-    name: Update Snapshot Pre-release on GitHub
+  publish-snapshot:
+    name: Publish Snapshot to Central
     needs: [check-snapshot]
     if: needs.check-snapshot.result == 'success'
+    runs-on: ubuntu-latest
+    environment: maven-central
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Deploy snapshot
+        run: mvn --batch-mode -P release deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Collect signed artifacts
+        run: |
+          mkdir -p signed-snapshot-assets
+          cp target/*.jar signed-snapshot-assets/ 2>/dev/null || true
+          cp target/*.jar.asc signed-snapshot-assets/ 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: signed-snapshot-assets
+          path: signed-snapshot-assets/
+
+  github-snapshot:
+    name: Update Snapshot Pre-release on GitHub
+    needs: [publish-snapshot]
+    if: needs.publish-snapshot.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: jars
+          name: signed-snapshot-assets
           path: snapshot-assets/
       - name: Update snapshot pre-release
         env:
@@ -166,28 +200,6 @@ jobs:
           gh release upload snapshot snapshot-assets/* \
             --repo ${{ github.repository }} \
             --clobber
-
-  publish-snapshot:
-    name: Publish Snapshot to Central
-    needs: [github-snapshot, check-snapshot]
-    if: needs.check-snapshot.result == 'success'
-    runs-on: ubuntu-latest
-    environment: maven-central
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: temurin
-          cache: maven
-          server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Deploy snapshot
-        run: mvn --batch-mode deploy -DskipTests
-        env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
 
   publish-release:
     name: Publish Release to Central

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,13 +36,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <java.test.version>17</java.test.version>
+        <java.test.version>21</java.test.version>
         <project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
     </properties>
     <inceptionYear>2014</inceptionYear>


### PR DESCRIPTION
## Summary

- Upgrade test Java version from 17 to 21 in `pom.xml` to align with runtime version
- Restructure snapshot publishing workflow: move Maven Central deployment before GitHub release update and add GPG signing support
- Update GitHub Actions dependencies: `upload-artifact` v4→v7 and `codeql-action/upload-sarif` v3→v4

## Test plan

- CI is green on this branch
- Existing unit tests pass with Java 21

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01SxxLmcu9vgaPjKnSPeTjEx