### PR TITLE
Preserve thread interrupt flag when wrapping InterruptedException

### DIFF
--- a/src/main/java/net/ladenthin/streambuffer/StreamBuffer.java
+++ b/src/main/java/net/ladenthin/streambuffer/StreamBuffer.java
@@ -796,6 +796,7 @@ public class StreamBuffer implements Closeable {
                 }
             }
             catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new IOException(e);
             }
 
@@ -852,6 +853,7 @@ public class StreamBuffer implements Closeable {
             try {
                 maximumAvailableBytes = tryWaitForEnoughBytes(missingBytes);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new IOException(e);
             }
 

--- a/src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java
+++ b/src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java
@@ -2409,7 +2409,7 @@ public class StreamBufferTest {
         final InputStream is = sb.getInputStream();
         final Semaphore started = new Semaphore(0);
         final Throwable[] caught = new Throwable[1];
-        final boolean[] interruptFlagAfterCatch = new boolean[1];
+        final AtomicBoolean interruptFlagAfterCatch = new AtomicBoolean(false);
 
         Thread reader = new Thread(() -> {
             try {
@@ -2417,7 +2417,7 @@ public class StreamBufferTest {
                 is.read(); // will block — no data, not closed
             } catch (IOException e) {
                 caught[0] = e;
-                interruptFlagAfterCatch[0] = Thread.currentThread().isInterrupted();
+                interruptFlagAfterCatch.set(Thread.currentThread().isInterrupted());
             }
         });
 
@@ -2432,7 +2432,7 @@ public class StreamBufferTest {
         assertThat("IOException should be thrown wrapping InterruptedException",
                 caught[0] instanceof IOException, is(true));
         assertThat("Thread interrupt flag must be preserved after wrapping InterruptedException",
-                interruptFlagAfterCatch[0], is(true));
+                interruptFlagAfterCatch.get(), is(true));
     }
 
     @DisplayName("read(): array thread interrupted while waiting for second byte — throws io exception")
@@ -2444,7 +2444,7 @@ public class StreamBufferTest {
         final OutputStream os = sb.getOutputStream();
         final Semaphore started = new Semaphore(0);
         final Throwable[] caught = new Throwable[1];
-        final boolean[] interruptFlagAfterCatch = new boolean[1];
+        final AtomicBoolean interruptFlagAfterCatch = new AtomicBoolean(false);
 
         // write exactly 1 byte so the internal read() at the start of read(b,off,len)
         // succeeds immediately, then tryWaitForEnoughBytes blocks waiting for the second byte
@@ -2456,7 +2456,7 @@ public class StreamBufferTest {
                 is.read(new byte[2], 0, 2);
             } catch (IOException e) {
                 caught[0] = e;
-                interruptFlagAfterCatch[0] = Thread.currentThread().isInterrupted();
+                interruptFlagAfterCatch.set(Thread.currentThread().isInterrupted());
             }
         });
 
@@ -2471,7 +2471,7 @@ public class StreamBufferTest {
         assertThat("IOException should be thrown wrapping InterruptedException",
                 caught[0] instanceof IOException, is(true));
         assertThat("Thread interrupt flag must be preserved after wrapping InterruptedException",
-                interruptFlagAfterCatch[0], is(true));
+                interruptFlagAfterCatch.get(), is(true));
     }
     }
 

--- a/src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java
+++ b/src/test/java/net/ladenthin/streambuffer/StreamBufferTest.java
@@ -2409,6 +2409,7 @@ public class StreamBufferTest {
         final InputStream is = sb.getInputStream();
         final Semaphore started = new Semaphore(0);
         final Throwable[] caught = new Throwable[1];
+        final boolean[] interruptFlagAfterCatch = new boolean[1];
 
         Thread reader = new Thread(() -> {
             try {
@@ -2416,6 +2417,7 @@ public class StreamBufferTest {
                 is.read(); // will block — no data, not closed
             } catch (IOException e) {
                 caught[0] = e;
+                interruptFlagAfterCatch[0] = Thread.currentThread().isInterrupted();
             }
         });
 
@@ -2429,6 +2431,8 @@ public class StreamBufferTest {
         // assert
         assertThat("IOException should be thrown wrapping InterruptedException",
                 caught[0] instanceof IOException, is(true));
+        assertThat("Thread interrupt flag must be preserved after wrapping InterruptedException",
+                interruptFlagAfterCatch[0], is(true));
     }
 
     @DisplayName("read(): array thread interrupted while waiting for second byte — throws io exception")
@@ -2440,6 +2444,7 @@ public class StreamBufferTest {
         final OutputStream os = sb.getOutputStream();
         final Semaphore started = new Semaphore(0);
         final Throwable[] caught = new Throwable[1];
+        final boolean[] interruptFlagAfterCatch = new boolean[1];
 
         // write exactly 1 byte so the internal read() at the start of read(b,off,len)
         // succeeds immediately, then tryWaitForEnoughBytes blocks waiting for the second byte
@@ -2451,6 +2456,7 @@ public class StreamBufferTest {
                 is.read(new byte[2], 0, 2);
             } catch (IOException e) {
                 caught[0] = e;
+                interruptFlagAfterCatch[0] = Thread.currentThread().isInterrupted();
             }
         });
 
@@ -2464,6 +2470,8 @@ public class StreamBufferTest {
         // assert
         assertThat("IOException should be thrown wrapping InterruptedException",
                 caught[0] instanceof IOException, is(true));
+        assertThat("Thread interrupt flag must be preserved after wrapping InterruptedException",
+                interruptFlagAfterCatch[0], is(true));
     }
     }
 


### PR DESCRIPTION
## Summary

- When `InterruptedException` is caught and wrapped in `IOException`, restore the thread's interrupt flag by calling `Thread.currentThread().interrupt()` before throwing
- This ensures that interrupt status is not lost when converting between exception types, allowing calling code to detect thread interruption
- Added assertions to existing tests to verify the interrupt flag is preserved after exception handling

## Test plan

- [x] Added assertions to `read_threadInterrupted_throwsIOException()` and `read_arrayThreadInterruptedWhileWaitingForSecondByte_throwsIOException()` to verify interrupt flag preservation
- [x] Affected unit tests pass locally
- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01X7vYXY4tqDSEsuNEKdnkHT