### PR TITLE
docs: add testing and analysis tool badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 **Build:**  
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)  
 ![JUnit](https://img.shields.io/badge/tested%20with-JUnit5-25A162)  
+[![jqwik](https://img.shields.io/badge/tested%20with-jqwik-1f6feb)](https://jqwik.net)  
+[![jcstress](https://img.shields.io/badge/tested%20with-jcstress-007396)](https://openjdk.org/projects/code-tools/jcstress/)  
+[![Lincheck](https://img.shields.io/badge/tested%20with-Lincheck-7F52FF)](https://github.com/JetBrains/lincheck)  
+[![vmlens](https://img.shields.io/badge/tested%20with-vmlens-ff6f00)](https://vmlens.com)  
+[![ArchUnit](https://img.shields.io/badge/tested%20with-ArchUnit-c71a36)](https://www.archunit.org)  
+[![SpotBugs](https://img.shields.io/badge/analyzed%20with-SpotBugs-3b5998)](https://spotbugs.github.io)  
+[![JMH](https://img.shields.io/badge/benchmarked%20with-JMH-25A162)](https://openjdk.org/projects/code-tools/jmh/)  
 [![Publish](https://github.com/bernardladenthin/streambuffer/actions/workflows/publish.yml/badge.svg)](https://github.com/bernardladenthin/streambuffer/actions/workflows/publish.yml)  
 [![CodeQL](https://github.com/bernardladenthin/streambuffer/actions/workflows/codeql.yml/badge.svg)](https://github.com/bernardladenthin/streambuffer/actions/workflows/codeql.yml)  
 


### PR DESCRIPTION
## Summary

- Added badges to the README documenting the testing and analysis tools used in the project
- Badges include: jqwik (property-based testing), jcstress (concurrency stress testing), Lincheck (linearizability testing), vmlens (interleaving analysis), ArchUnit (architecture testing), SpotBugs (static analysis), and JMH (benchmarking)
- Improves project visibility by showcasing the comprehensive quality assurance approach

## Test plan

- [x] No testing needed — documentation-only change

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01CHrP8SJy37aUTfQfbh8xyw