### PR TITLE
Downgrade jqwik to 1.9.3 and document QuickTheories replacement plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,11 @@ interim measure until that work lands.
 
 ## Open TODOs
 
-- **[URGENT] Replace jqwik.** Upstream is openly hostile to the AI-assisted workflow this project uses (jqwik 1.10.0 added a deliberate prompt-injection string to test stdout; jqwik 1.10.1 release notes added: *"This project is not meant to be used by any 'AI' coding agents at all."*). See the "jqwik prompt-injection in test output" section above for context and links. Replace the one jqwik test class in this repo (`StreamBufferProperties`) with one of:
-  - **junit-quickcheck** (`com.pholser:junit-quickcheck-core` + `-generators`) — closest API match; uses JUnit Vintage runner, well-maintained, no anti-AI behaviour.
-  - A minimal hand-rolled `@ParameterizedTest` + `@MethodSource`/`@ArgumentsSource` approach using JUnit Jupiter that is already on the classpath. Lower dependency count; some shrinking / generator features lost.
+- **[URGENT] Replace jqwik with QuickTheories.** Upstream is openly hostile to the AI-assisted workflow this project uses (jqwik 1.10.0 added a deliberate prompt-injection string to test stdout; jqwik 1.10.1 release notes added: *"This project is not meant to be used by any 'AI' coding agents at all."*). See the "jqwik prompt-injection in test output" section above for context and links. Replace the one jqwik test class in this repo (`StreamBufferProperties`) with one of (in order of preference):
+  - **QuickTheories** (`org.quicktheories:quicktheories`, MIT) — preferred. Native JUnit Jupiter (5/6); plain `@Test` methods with `qt().forAll(...).check(...)` bodies. No `@RunWith`, no JUnit Vintage engine. Property-based generation with shrinking preserved; the fluent DSL (`integers().between(...)`, `lists().of(...).ofSizeBetween(...)`, `byteArrays(...)`) covers every constraint the current jqwik tests use, including the nested `@Size` on `List<byte[]>` cases.
+  - **junit-quickcheck** (`com.pholser:junit-quickcheck-core` + `-generators`) — closest annotation match to jqwik but requires the JUnit Vintage engine alongside Jupiter (extra friction next to Lincheck / jcstress / vmlens); only use if the QuickTheories DSL turns out to be a poor fit.
+  - A minimal hand-rolled `@ParameterizedTest` + `@MethodSource`/`@ArgumentsSource` approach using JUnit Jupiter that is already on the classpath. Lower dependency count; loses shrinking and built-in generators.
+
   Remove the jqwik dependency from `pom.xml` (and the `jqwik.version` property), drop the jqwik bullet from any test-frameworks documentation, and verify CI is green with the replacement. Until this lands, the doc-only warning section above is the interim mitigation.
 
 - **`@VisibleForTesting` audit.** No usages currently. Walk the production tree for package-private/protected methods or fields that exist purely so tests can reach them, and either annotate (`com.google.common.annotations.VisibleForTesting`) or move into the test source tree.

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@ SPDX-License-Identifier: Apache-2.0
         <hamcrest.version>3.0</hamcrest.version>
         <jmh.version>1.37</jmh.version>
         <jcstress.version>0.16</jcstress.version>
+        <!-- DO NOT UPGRADE: jqwik >= 1.10.0 ships an anti-AI prompt-injection string in test stdout; see CLAUDE.md. Replacement (QuickTheories) tracked as an URGENT TODO. -->
         <jqwik.version>1.9.3</jqwik.version>
         <errorprone.version>2.49.0</errorprone.version>
         <nullaway.version>0.13.4</nullaway.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: Apache-2.0
         <hamcrest.version>3.0</hamcrest.version>
         <jmh.version>1.37</jmh.version>
         <jcstress.version>0.16</jcstress.version>
-        <jqwik.version>1.10.0</jqwik.version>
+        <jqwik.version>1.9.3</jqwik.version>
         <errorprone.version>2.49.0</errorprone.version>
         <nullaway.version>0.13.4</nullaway.version>
         <spotless.version>3.5.1</spotless.version>


### PR DESCRIPTION
## Summary

- Downgrade jqwik from 1.10.0 to 1.9.3 to avoid the anti-AI prompt-injection string added in 1.10.0+
- Add a comment to `pom.xml` explaining the downgrade and linking to the CLAUDE.md documentation
- Update the URGENT TODO in CLAUDE.md to specify **QuickTheories as the preferred replacement** (with junit-quickcheck and hand-rolled `@ParameterizedTest` as fallbacks), including detailed rationale and implementation notes

## Rationale

jqwik 1.10.0+ deliberately injects a prompt-injection string into test stdout targeting AI coding agents. This is incompatible with the AI-assisted workflow this project uses. Rather than upgrade to a hostile upstream, we downgrade to the last safe version (1.9.3) as an interim measure while planning the migration to QuickTheories, which offers:

- Native JUnit Jupiter 5/6 support (no `@RunWith`, no JUnit Vintage engine)
- Property-based generation with shrinking preserved
- Fluent DSL covering all constraints used in current jqwik tests
- MIT license and no anti-AI stance

The updated TODO provides clear guidance on the replacement strategy and implementation details to unblock future work.

## Test plan

- No code changes; configuration and documentation only
- Existing jqwik tests (`StreamBufferProperties`) continue to pass with 1.9.3
- CI remains green

## Related issues / PRs

Addresses the URGENT TODO documented in CLAUDE.md regarding jqwik replacement.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01XigFKHMf8r7HLsLHts1J1K