### PR TITLE
Upgrade NullAway to 0.13.6 and JaCoCo to 0.8.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
              section "jqwik prompt-injection in test output" for full context. -->
         <jqwik.version>1.9.3</jqwik.version>
         <errorprone.version>2.49.0</errorprone.version>
-        <nullaway.version>0.13.4</nullaway.version>
+        <nullaway.version>0.13.6</nullaway.version>
         <jspecify.version>1.0.0</jspecify.version>
         <checker.version>4.2.0</checker.version>
         <spotless.version>3.6.0</spotless.version>
@@ -245,7 +245,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.14</version>
+                    <version>0.8.15</version>
                 </plugin>
                 <plugin>
                     <groupId>org.pitest</groupId>


### PR DESCRIPTION
## Summary

- Upgrade NullAway from 0.13.4 to 0.13.6
- Upgrade JaCoCo Maven plugin from 0.8.14 to 0.8.15

These are minor version updates to development and build tooling dependencies with no source code changes.

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01Dd2pKJ9sid6Dh4v1AnYGmV