### PR TITLE
Add code-style job to CI pipeline with spotless and jdeps checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,25 @@ jobs:
     steps:
       - run: echo "Start gate elapsed — proceeding with pipeline."
 
+  code-style:
+    name: Code style (spotless) + package graph
+    needs: startgate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+      - name: Spotless check (fail fast on format violations)
+        run: mvn -B --no-transfer-progress spotless:check
+      - name: Print internal package dependency graph (jdeps, informational)
+        continue-on-error: true
+        run: |
+          mvn -B --no-transfer-progress -DskipTests -Denforcer.skip=true compile
+          echo "=== internal package dependency graph (jdeps, bytecode) ==="
+          jdeps -verbose:package target/classes | grep 'net.ladenthin.streambuffer' || true
+
   build:
     name: Build
     needs: startgate
@@ -160,7 +179,7 @@ jobs:
 
   publish-snapshot:
     name: Publish Snapshot to Central
-    needs: [check-snapshot]
+    needs: [check-snapshot, code-style]
     if: needs.check-snapshot.result == 'success'
     runs-on: ubuntu-latest
     environment: maven-central
@@ -220,7 +239,7 @@ jobs:
 
   publish-release:
     name: Publish Release to Central
-    needs: [check-tag]
+    needs: [check-tag, code-style]
     if: needs.check-tag.result == 'success'
     runs-on: ubuntu-latest
     environment: maven-central

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,7 @@ jobs:
           format: jacoco
         continue-on-error: true
       - name: Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/site/jacoco/jacoco.xml


### PR DESCRIPTION
## Summary

- Added a new `code-style` CI job that runs Spotless code formatting checks and prints the internal package dependency graph via jdeps
- Made the `code-style` job a required dependency for both snapshot and release publishing workflows
- This ensures code style violations are caught early and fail fast before publishing artifacts

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_018JD9GHTJ3GNaT57iqfK3nP