### PR TITLE
docs: add JPMS module descriptor policy guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,14 @@ See [`../workspace/policies/spotbugs-suppressions.md`](../workspace/policies/spo
 
 See [`../workspace/policies/jqwik-prompt-injection.md`](../workspace/policies/jqwik-prompt-injection.md).
 
+## JPMS Module Descriptor
+
+This repo ships a `module-info.java` compiled in a separate `release 9` execution. Javadoc
+currently runs in **classpath mode** (javadoc `<source>` resolves to `8`), which is the *only*
+thing keeping it clear of the JPMS module-mode javadoc trap that bit BAF. **Before raising the
+Java / javadoc source level to ≥ 9, read**
+[`../workspace/policies/jpms-module-descriptor.md`](../workspace/policies/jpms-module-descriptor.md).
+
 ## Open TODOs
 
 Open TODOs for this repo live in [`TODO.md`](TODO.md). Cross-repo status


### PR DESCRIPTION
## Summary

- Added documentation section to `CLAUDE.md` warning about JPMS module descriptor considerations
- References new policy document at `../workspace/policies/jpms-module-descriptor.md` with detailed guidance
- Highlights that javadoc currently runs in classpath mode (source level 8) to avoid module-mode pitfalls
- Advises reading the policy before raising Java/javadoc source level to ≥ 9

## Test plan

N/A — documentation-only change

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01LmHENudRrQiLao8vAPmmCB