### PR TITLE
Configure Dependabot to block all jqwik updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Anti-AI policy: jqwik >=1.10 injects prompts targeting AI agents in test
+    # stdout. Pinned at 1.9.3; block ALL net.jqwik updates. See README.
+    ignore:
+      - dependency-name: "net.jqwik:*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Test coverage includes:
 
 ### Contributors: do not upgrade jqwik past 1.9.3
 
-> ⚠️ **DO NOT UPGRADE jqwik past 1.9.3.** jqwik 1.10.0 added an anti-AI prompt-injection string to test stdout; the 1.10.1 user guide states the library "is not meant to be used by any 'AI' coding agents at all." 1.9.3 is the last pre-disclosure release and is the pinned version. See `CLAUDE.md` section "jqwik prompt-injection in test output" for the full context.
+> ⚠️ **DO NOT UPGRADE jqwik past 1.9.3.** jqwik 1.10.0 added an anti-AI prompt-injection string to test stdout; the 1.10.1 user guide states the library "is not meant to be used by any 'AI' coding agents at all." 1.9.3 is the last pre-disclosure release and is the pinned version. See `CLAUDE.md` section "jqwik prompt-injection in test output" for the full context. Dependabot is configured to ignore **all** `net.jqwik` updates (every version, including patches) — see the `ignore` rule in [`.github/dependabot.yml`](./.github/dependabot.yml).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Added Dependabot `ignore` rule to block **all** `net.jqwik` updates (every version and patch) in `.github/dependabot.yml`
- Updated README to clarify that Dependabot is configured to enforce the jqwik 1.9.3 pinning policy and reference the configuration location

## Rationale

jqwik 1.10.0+ contains anti-AI prompt-injection strings in test output. The project pins jqwik at 1.9.3 (the last pre-disclosure release) to avoid this. This change automates enforcement of that policy by preventing Dependabot from proposing any jqwik version upgrades, eliminating the need for manual review and rejection of such PRs.

## Test plan

- [x] CI is green on this branch
- [x] Docs updated (README clarified with reference to Dependabot configuration)

## Related issues / PRs

<!-- None -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01XEjgThAas1gQV65HK6kSqM