### PR TITLE
Upgrade palantir-java-format to 2.92.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         <jspecify.version>1.0.0</jspecify.version>
         <checker.version>4.2.0</checker.version>
         <spotless.version>3.6.0</spotless.version>
-        <palantir-java-format.version>2.91.0</palantir-java-format.version>
+        <palantir-java-format.version>2.92.0</palantir-java-format.version>
         <spotbugs.version>4.10.2.0</spotbugs.version>
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>


### PR DESCRIPTION
## Summary

- Upgrade `palantir-java-format` dependency from 2.91.0 to 2.92.0 in `pom.xml`
- This is a minor version bump of the code formatting tool used by Spotless

## Test plan

- [x] CI is green on this branch
- [x] No source code changes affected

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_014yVpSSsdKVEjrYwLek3tTK