### PR TITLE
ci: Replace CodeQL autobuild with explicit Maven compile

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,7 @@ jobs:
         with: { java-version: '21', distribution: temurin }
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }
-      - uses: github/codeql-action/autobuild@v4
+      - name: Build with Maven
+        run: mvn --batch-mode compile
       - uses: github/codeql-action/analyze@v4
         with: { category: "/language:java" }

--- a/src/main/java/net/ladenthin/streambuffer/StreamBuffer.java
+++ b/src/main/java/net/ladenthin/streambuffer/StreamBuffer.java
@@ -531,14 +531,6 @@ public class StreamBuffer implements Closeable {
     }
 
     /**
-     * Checks if a trim should be performed.
-     * Critical: Ensures trim will actually reduce buffer chunks below {@link #maxBufferElements}.
-     * If consolidating would create chunks that still exceed the limit (when respecting
-     * {@link #maxAllocationSize}), trim is skipped to prevent repeated trim calls on every write.
-     *
-     * @return <code>true</code> if a trim should be performed, otherwise <code>false</code>.
-     */
-    /**
      * Pure function to decide if trim should execute based on buffer state.
      * Contains all decision logic for the trim decision tree:
      * - maxBufferElements validity check (&#x2264; 0 is invalid)


### PR DESCRIPTION
## Summary

- Replace the generic CodeQL `autobuild` action with an explicit `mvn --batch-mode compile` step in the CodeQL workflow
- Ensures consistent, reproducible builds during security analysis by using the project's standard Maven build command
- Improves transparency and control over the build process used for code scanning

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01FGnfLjjGbiZxknfbUnnwUr