### PR TITLE
Suppress Maven transfer progress output in CI workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }
       - name: Build with Maven
-        run: mvn --batch-mode compile
+        run: mvn --batch-mode --no-transfer-progress compile
       - uses: github/codeql-action/analyze@v4
         with: { category: "/language:java" }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Build
-        run: mvn --batch-mode -DskipTests -Dmaven.javadoc.skip=true package
+        run: mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.javadoc.skip=true package
       - uses: actions/upload-artifact@v7
         with: { name: jars, path: target/*.jar }
 
@@ -77,7 +77,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Test
-        run: mvn --batch-mode -P jcstress verify -Dmaven.javadoc.skip=true
+        run: mvn --batch-mode --no-transfer-progress -P jcstress verify -Dmaven.javadoc.skip=true
       - uses: actions/upload-artifact@v7
         if: matrix.java-version == '21'
         with:
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-java@v5
         with: { java-version: '21', distribution: temurin, cache: maven }
       - name: Test under vmlens
-        run: mvn --batch-mode -Pvmlens test -Dmaven.javadoc.skip=true
+        run: mvn --batch-mode --no-transfer-progress -Pvmlens test -Dmaven.javadoc.skip=true
       - uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -130,7 +130,7 @@ jobs:
           files: target/site/jacoco/jacoco.xml
         continue-on-error: true
       - name: Run PIT mutation tests
-        run: mvn --batch-mode test-compile org.pitest:pitest-maven:mutationCoverage -Dmaven.javadoc.skip=true
+        run: mvn --batch-mode --no-transfer-progress test-compile org.pitest:pitest-maven:mutationCoverage -Dmaven.javadoc.skip=true
       - name: Extract PIT survivors
         if: always()
         run: |
@@ -147,7 +147,7 @@ jobs:
         with: { name: pit-reports, path: target/pit-reports/ }
       - name: Run JMH benchmarks
         run: >
-          mvn --batch-mode exec:java
+          mvn --batch-mode --no-transfer-progress exec:java
           -Dexec.mainClass=org.openjdk.jmh.Main
           -Dexec.classpathScope=test
           -Dexec.args="StreamBufferThroughputBenchmark -wi 2 -i 3 -f 0 -rf json -rff target/jmh-results.json"
@@ -196,7 +196,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Deploy snapshot
-        run: mvn --batch-mode -P release deploy -DskipTests
+        run: mvn --batch-mode --no-transfer-progress -P release deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
@@ -258,7 +258,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Deploy release
-        run: mvn --batch-mode -P release deploy -DskipTests
+        run: mvn --batch-mode --no-transfer-progress -P release deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=bernardladenthin_streambuffer
+        run: mvn -B --no-transfer-progress verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=bernardladenthin_streambuffer


### PR DESCRIPTION
## Summary

- Add `--no-transfer-progress` flag to all Maven commands in CI workflows to reduce log verbosity
- Applies to build, test, deploy, and analysis jobs across `publish.yml`, `codeql.yml`, and `sonarqube.yml`
- Improves CI log readability by suppressing repetitive artifact download progress messages

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01RcJfwgM2cfjd3n5A8JrGqe