### PR TITLE
Add CI test diagnostics: memory monitoring and crash dump capture

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,13 +76,31 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: temurin
           cache: maven
+      - name: Memory before tests
+        run: free -h
       - name: Test
-        run: mvn --batch-mode --no-transfer-progress -P jcstress verify
+        run: mvn -e --batch-mode --no-transfer-progress -P jcstress verify
       - uses: actions/upload-artifact@v7
         if: matrix.java-version == '21'
         with:
           name: jacoco-report
           path: target/site/jacoco/jacoco.xml
+          if-no-files-found: ignore
+      - name: Memory after tests
+        if: always()
+        run: free -h
+      - name: Upload crash & surefire dumps
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-dumps-jdk${{ matrix.java-version }}
+          path: |
+            ${{ github.workspace }}/hs_err_pid*.log
+            ${{ github.workspace }}/*.hprof
+            ${{ github.workspace }}/target/surefire-reports/*.dump
+            ${{ github.workspace }}/target/surefire-reports/*.dumpstream
+            ${{ github.workspace }}/target/surefire-reports/*.txt
+            ${{ github.workspace }}/target/surefire-reports/TEST-*.xml
           if-no-files-found: ignore
 
   vmlens:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,10 @@ Run `mvn spotless:apply` before every commit that touches `.java` files.
 
 See [`../workspace/policies/jqwik-prompt-injection.md`](../workspace/policies/jqwik-prompt-injection.md).
 
+## CI Test Diagnostics
+
+See [`../workspace/policies/ci-test-diagnostics.md`](../workspace/policies/ci-test-diagnostics.md).
+
 ## JPMS Module Descriptor
 
 This repo ships a `module-info.java` compiled in a separate `release 9` execution. Javadoc

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,14 @@ SPDX-License-Identifier: Apache-2.0
                     <version>3.5.6</version>
                     <configuration>
                         <!--
+                            @{argLine} is the JaCoCo-populated property (late replacement); it
+                            MUST come first so the JaCoCo agent stays attached and coverage keeps
+                            working. The remaining flags cap the test heap and capture crash
+                            diagnostics: a heap dump on OutOfMemoryError plus a per-pid hs_err
+                            file, both written to the working directory so CI can upload them.
+                        -->
+                        <argLine>@{argLine} -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=. -XX:ErrorFile=hs_err_pid%p.log</argLine>
+                        <!--
                             Tests in the `vmlens` package are meaningful only under the vmlens
                             agent (the `vmlens` profile). Without the agent an AllInterleavings
                             loop body never runs (a vacuous pass that prints an "agent not


### PR DESCRIPTION
## Summary

- Add memory monitoring (`free -h`) before and after test execution in the jcstress CI workflow to track resource usage
- Capture JVM crash diagnostics (heap dumps, hs_err logs, surefire reports) on test failure for post-mortem analysis
- Configure Maven Surefire with heap limits (`-Xmx2g`) and diagnostic flags to generate crash artifacts in the working directory
- Document CI test diagnostics policy in `CLAUDE.md`

## Test plan

- [x] CI is green on this branch (workflow changes are syntactically valid and artifact upload paths are correct)
- [x] Existing tests pass (no code logic changes, only CI configuration and JVM flags)

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01JBzF5wtCjRu5t4FMzphryM