### PR TITLE
Upgrade spotless and central-publishing-maven-plugin dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
         <nullaway.version>0.13.6</nullaway.version>
         <jspecify.version>1.0.0</jspecify.version>
         <checker.version>4.2.0</checker.version>
-        <spotless.version>3.6.0</spotless.version>
+        <spotless.version>3.7.0</spotless.version>
         <palantir-java-format.version>2.92.0</palantir-java-format.version>
         <spotbugs.version>4.10.2.0</spotbugs.version>
         <fb-contrib.version>7.7.4</fb-contrib.version>
@@ -292,7 +292,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.10.0</version>
+                    <version>0.11.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Summary

- Upgrade `spotless` from 3.6.0 to 3.7.0
- Upgrade `central-publishing-maven-plugin` from 0.10.0 to 0.11.0

## Test plan

- [ ] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01HfEmuuUiRwnciLxNAKw2Sf