### PR TITLE
Bump nullaway to 0.13.7 and pitest-maven to 1.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
              section "jqwik prompt-injection in test output" for full context. -->
         <jqwik.version>1.9.3</jqwik.version>
         <errorprone.version>2.50.0</errorprone.version>
-        <nullaway.version>0.13.6</nullaway.version>
+        <nullaway.version>0.13.7</nullaway.version>
         <jspecify.version>1.0.0</jspecify.version>
         <checker.version>4.2.0</checker.version>
         <spotless.version>3.7.0</spotless.version>
@@ -287,7 +287,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.4</version>
+                    <version>1.25.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
## Summary

- Upgrade NullAway from 0.13.6 to 0.13.7
- Upgrade pitest-maven from 1.25.4 to 1.25.5

These are patch-level dependency updates that bring in bug fixes and improvements from the upstream projects.

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01LjWiKSyNzqqpobSKYRiew5