### PR TITLE
docs: add AI-assisted development note and Claude badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!NOTE]
+> **No IDE or local setup required.** This repository is optimized for fully AI-assisted development using [Claude Code](https://claude.ai/code). No local toolchain, no IDE, nothing to install — everything works completely through Claude.
+
+**AI:**  
+[![Claude](https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff)](#)  
+
 **Build:**  
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)  
 [![JPMS](https://img.shields.io/badge/JPMS-modular%20JAR-25A162)](https://openjdk.org/projects/jigsaw/)  


### PR DESCRIPTION
## Summary

- Added a prominent note at the top of README.md highlighting that the repository is optimized for AI-assisted development using Claude Code with no local setup required
- Added a Claude badge to the "AI" section to indicate the project's AI development capability

## Test plan

N/A — documentation-only change

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01HBz49Je54TcVoPVmQyMgif