### PR TITLE
docs: clarify PIT mutation testing setup and add policy reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,14 +16,11 @@ mvn install -Dgpg.skip=true  # Install to local repo without GPG signing
 mvn test -Dtest=StreamBufferTest#testSimpleRoundTrip
 ```
 
-**Run mutation tests:**
+**Run mutation tests** (the `test-compile` prefix is required — see the
+[PIT policy](../workspace/policies/pit-mutation-testing.md)):
 ```bash
 mvn test-compile org.pitest:pitest-maven:mutationCoverage
 ```
-The `test-compile` prefix is required: it triggers JaCoCo's `prepare-agent` so the
-surefire `@{argLine}` resolves. The bare `mvn org.pitest:pitest-maven:mutationCoverage`
-fails with `NoSuchFileException: {argLine}`. See
-[`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md).
 
 **Run JMH benchmarks:**
 
@@ -116,9 +113,7 @@ See [`../workspace/policies/ci-test-diagnostics.md`](../workspace/policies/ci-te
 ## PIT Mutation Testing
 
 See [`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md).
-Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`
-(the bare goal fails with `NoSuchFileException: {argLine}`). The gate covers the whole
-`net.ladenthin.streambuffer` package at a 100% threshold.
+Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`.
 
 ## JPMS Module Descriptor
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,12 @@ mvn test -Dtest=StreamBufferTest#testSimpleRoundTrip
 
 **Run mutation tests:**
 ```bash
-mvn org.pitest:pitest-maven:mutationCoverage
+mvn test-compile org.pitest:pitest-maven:mutationCoverage
 ```
+The `test-compile` prefix is required: it triggers JaCoCo's `prepare-agent` so the
+surefire `@{argLine}` resolves. The bare `mvn org.pitest:pitest-maven:mutationCoverage`
+fails with `NoSuchFileException: {argLine}`. See
+[`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md).
 
 **Run JMH benchmarks:**
 
@@ -108,6 +112,13 @@ See [`../workspace/policies/jqwik-prompt-injection.md`](../workspace/policies/jq
 ## CI Test Diagnostics
 
 See [`../workspace/policies/ci-test-diagnostics.md`](../workspace/policies/ci-test-diagnostics.md).
+
+## PIT Mutation Testing
+
+See [`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md).
+Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`
+(the bare goal fails with `NoSuchFileException: {argLine}`). The gate covers the whole
+`net.ladenthin.streambuffer` package at a 100% threshold.
 
 ## JPMS Module Descriptor
 

--- a/README.md
+++ b/README.md
@@ -381,10 +381,11 @@ Run a single test:
 mvn test -Dtest=StreamBufferTest#testSimpleRoundTrip
 ```
 
-Run mutation tests:
+Run mutation tests (the `test-compile` prefix is required so JaCoCo's `prepare-agent`
+resolves the surefire `@{argLine}`; the bare goal fails with `NoSuchFileException: {argLine}`):
 
 ```bash
-mvn org.pitest:pitest-maven:mutationCoverage
+mvn test-compile org.pitest:pitest-maven:mutationCoverage
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -381,8 +381,7 @@ Run a single test:
 mvn test -Dtest=StreamBufferTest#testSimpleRoundTrip
 ```
 
-Run mutation tests (the `test-compile` prefix is required so JaCoCo's `prepare-agent`
-resolves the surefire `@{argLine}`; the bare goal fails with `NoSuchFileException: {argLine}`):
+Run mutation tests (the `test-compile` prefix is required so PIT inherits JaCoCo's agent):
 
 ```bash
 mvn test-compile org.pitest:pitest-maven:mutationCoverage


### PR DESCRIPTION
## Summary

- Updated mutation testing command in `CLAUDE.md` and `README.md` to include the required `test-compile` lifecycle prefix
- Added explanation that `test-compile` is needed so PIT inherits JaCoCo's agent
- Added new "PIT Mutation Testing" section to `CLAUDE.md` with reference to the policy document and correct invocation syntax

## Test plan

- [ ] CI is green on this branch
- [ ] Docs / CHANGELOG updated where applicable

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_017i6A5bMhgCSbiKibQhxwuz