### PR TITLE
Add SpotBugs static analysis check to CI pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,8 @@ jobs:
           distribution: temurin
       - name: Spotless check (fail fast on format violations)
         run: mvn -B --no-transfer-progress spotless:check
+      - name: SpotBugs check (fail fast on static-analysis findings)
+        run: mvn -B --no-transfer-progress -DskipTests -Denforcer.skip=true compile spotbugs:check
       - name: Print internal package dependency graph (jdeps, informational)
         continue-on-error: true
         run: |


### PR DESCRIPTION
## Summary

- Add SpotBugs static analysis check to the publish workflow to catch potential bugs early in CI
- Run SpotBugs during the build phase with test compilation and enforcer checks skipped to fail fast on findings
- Complements existing Spotless formatting checks with additional code quality validation

## Test plan

- [x] CI is green on this branch (SpotBugs check passes with no violations)

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_0137c1LhUbNvW3kt4eF9Kqyb