### PR TITLE
chore: upgrade GitHub Actions cache and dependencies

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -23,13 +23,13 @@ jobs:
           java-version: 21
           distribution: 'zulu'
       - name: Cache SonarQube packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>8</java.version>
         <java.test.version>21</java.test.version>
-        <junit.version>6.1.0</junit.version>
+        <junit.version>6.1.1</junit.version>
         <hamcrest.version>3.0</hamcrest.version>
         <jmh.version>1.37</jmh.version>
         <jcstress.version>0.16</jcstress.version>
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         <jspecify.version>1.0.0</jspecify.version>
         <checker.version>4.2.0</checker.version>
         <spotless.version>3.7.0</spotless.version>
-        <palantir-java-format.version>2.92.0</palantir-java-format.version>
+        <palantir-java-format.version>2.94.0</palantir-java-format.version>
         <spotbugs.version>4.10.2.0</spotbugs.version>
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>


### PR DESCRIPTION
## Summary

- Upgrade `actions/cache` from v5 to v6 in SonarQube workflow
- Bump JUnit from 6.1.0 to 6.1.1
- Bump Palantir Java Format from 2.92.0 to 2.94.0

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01DxT73BpL3JQyFn2SoXhnuJ