### PR TITLE
docs: point RELEASE.md at centralized workspace release procedure

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,34 +1,7 @@
 # Release Process
 
-The following prompt template is used to drive a Maven Central release. Paste it into a new Claude Code session, fill in the three placeholders, and send it to perform a release.
+The maintainer-facing release procedure is **centralized in the workspace repo**:
+[`../workspace/workflows/release-process.md`](../workspace/workflows/release-process.md).
 
-```
-Release `{PROJECT}` to Maven Central.
-
-**Step 1 — Prepare the release (do immediately):**
-1. Read the current version from `pom.xml` on `main` — it will be `{VERSION}-SNAPSHOT`
-2. Strip `-SNAPSHOT` from `pom.xml` (→ `{VERSION}`)
-3. In `README.md`, update **both**:
-   - The release dependency example to `{VERSION}`
-   - The snapshot dependency example to `{VERSION}-SNAPSHOT` (it should already match, but verify)
-4. Commit both files directly to `main` (no pull request)
-
-**Step 2 — Wait for manual confirmation:**
-I will create the `v{VERSION}` tag and GitHub release manually — wait for me to confirm
-the release is published on Maven Central before proceeding.
-
-**Step 3 — Post-release snapshot bump (after my confirmation):**
-Bump **both** files on `main`:
-- `pom.xml` → `{NEXT_VERSION}-SNAPSHOT`
-- `README.md` snapshot dependency example → `{NEXT_VERSION}-SNAPSHOT`
-
-Commit both changes together directly to `main`.
-
-**Placeholders:**
-
-| Placeholder      | Value                                        |
-|------------------|----------------------------------------------|
-| `{PROJECT}`      | *(project name)*                             |
-| `{VERSION}`      | *(release version, e.g. `1.3.0`)*           |
-| `{NEXT_VERSION}` | *(next snapshot base, e.g. `1.3.1`)*        |
-```
+streambuffer is a single-module Maven project (one `pom.xml`, one `README.md` dependency
+snippet), so the canonical procedure applies as-is — there is no repo-specific supplement.


### PR DESCRIPTION
The maintainer-facing release procedure is now centralized in `workspace/workflows/release-process.md` (see the workspace PR). This replaces streambuffer's duplicated copy with a pointer to it — a pure single-module repo, so no repo-specific supplement.

De-stales the old copy, which said "commit directly to `main` (no PR)", omitted the `CHANGELOG.md` finalization step, and never mentioned the `publish_to_central=true` deploy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEgh6vtcPWAgQ6scK8pJk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEgh6vtcPWAgQ6scK8pJk7)_