### PR TITLE
Improve Central publishing resilience and add debug visibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -239,12 +239,18 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      # Runs even when the deploy step failed: a Central publish-poll timeout reds the
+      # job *after* the bundle was uploaded (and typically published server-side), while
+      # the signed jars + .asc files already exist in target/ (signing happens at
+      # verify). Collecting on failure lets the github-snapshot job still attach them.
       - name: Collect signed artifacts
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p signed-snapshot-assets
           cp target/*.jar signed-snapshot-assets/ 2>/dev/null || true
           cp target/*.jar.asc signed-snapshot-assets/ 2>/dev/null || true
       - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
         with:
           name: signed-snapshot-assets
           path: signed-snapshot-assets/
@@ -252,7 +258,10 @@ jobs:
   github-snapshot:
     name: Update Snapshot Pre-release on GitHub
     needs: [publish-snapshot]
-    if: needs.publish-snapshot.result == 'success'
+    # Also runs when publish-snapshot FAILED (not when skipped/cancelled): a Central
+    # publish-poll timeout reds that job after the artifacts were already uploaded —
+    # the GitHub pre-release assets must not be lost in that case.
+    if: ${{ !cancelled() && (needs.publish-snapshot.result == 'success' || needs.publish-snapshot.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -306,12 +315,18 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      # Runs even when the deploy step failed: a Central publish-poll timeout reds the
+      # job *after* the bundle was uploaded (and typically published server-side), while
+      # the signed jars + .asc files already exist in target/ (signing happens at
+      # verify). Collecting on failure lets the github-release job still attach them.
       - name: Collect signed artifacts
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p signed-release-assets
           cp target/*.jar signed-release-assets/ 2>/dev/null || true
           cp target/*.jar.asc signed-release-assets/ 2>/dev/null || true
       - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
         with:
           name: signed-release-assets
           path: signed-release-assets/
@@ -319,7 +334,10 @@ jobs:
   github-release:
     name: Attach Binaries to GitHub Release
     needs: [publish-release]
-    if: needs.publish-release.result == 'success'
+    # Also runs when publish-release FAILED (not when skipped/cancelled): a Central
+    # publish-poll timeout reds that job after the artifacts were already uploaded —
+    # the GitHub release assets must not be lost in that case.
+    if: ${{ !cancelled() && (needs.publish-release.result == 'success' || needs.publish-release.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -228,6 +228,11 @@ jobs:
             *-SNAPSHOT) echo "OK: -SNAPSHOT version, continuing snapshot deploy." ;;
             *) echo "::error::Refusing to publish non-SNAPSHOT version '$VERSION' from the snapshot job. Snapshot publishing requires a -SNAPSHOT version; releases go through the v* tag path."; exit 1 ;;
           esac
+      # Informational only (nothing depends on it): logs the effective POM with the same
+      # profile as the deploy below, so the resolved central-publishing configuration
+      # (waitUntil/waitMaxTime etc.) is visible for debugging.
+      - name: Show effective POM (debug)
+        run: mvn --batch-mode --no-transfer-progress -P release help:effective-pom
       - name: Deploy snapshot
         run: mvn --batch-mode --no-transfer-progress -P release deploy -DskipTests
         env:
@@ -290,6 +295,11 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      # Informational only (nothing depends on it): logs the effective POM with the same
+      # profile as the deploy below, so the resolved central-publishing configuration
+      # (waitUntil/waitMaxTime etc.) is visible for debugging.
+      - name: Show effective POM (debug)
+        run: mvn --batch-mode --no-transfer-progress -P release help:effective-pom
       - name: Deploy release
         run: mvn --batch-mode --no-transfer-progress -P release deploy -DskipTests
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -725,10 +725,7 @@ SPDX-License-Identifier: Apache-2.0
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <!-- validated (not published): wait only for portal validation, which is where
-                                 real errors (bad signature, POM rules) surface; the publish step then runs
-                                 server-side via autoPublish. Waiting for "published" timed out on a slow
-                                 Central day (jllama 5.0.6 release) although the deployment published fine. -->
+                            <!-- validated: wait only for portal validation (where real errors surface), not the slow server-side publish; autoPublish completes it -->
                             <waitUntil>validated</waitUntil>
                             <!-- seconds; generous headroom for the validation poll (default 1800) -->
                             <waitMaxTime>21600</waitMaxTime>

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.5</version>
+                    <version>1.25.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -725,8 +725,12 @@ SPDX-License-Identifier: Apache-2.0
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
-                            <!-- seconds (6 h); the default 1800 timed out on a slow Central day (jllama 5.0.6 release) -->
+                            <!-- validated (not published): wait only for portal validation, which is where
+                                 real errors (bad signature, POM rules) surface; the publish step then runs
+                                 server-side via autoPublish. Waiting for "published" timed out on a slow
+                                 Central day (jllama 5.0.6 release) although the deployment published fine. -->
+                            <waitUntil>validated</waitUntil>
+                            <!-- seconds; generous headroom for the validation poll (default 1800) -->
                             <waitMaxTime>21600</waitMaxTime>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -726,6 +726,8 @@ SPDX-License-Identifier: Apache-2.0
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
                             <waitUntil>published</waitUntil>
+                            <!-- seconds (6 h); the default 1800 timed out on a slow Central day (jllama 5.0.6 release) -->
+                            <waitMaxTime>21600</waitMaxTime>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary

- **Improve Central publishing resilience**: Change `waitUntil` from `published` to `validated` to avoid timeouts after artifacts are already uploaded and published server-side. Increase `waitMaxTime` from default 1800s to 21600s (6 hours) to provide generous headroom for validation polling.
- **Ensure artifact preservation on deploy failure**: Update `github-snapshot` and `github-release` job conditions to run even when their upstream publish jobs fail (not just on success), so signed artifacts collected after a Central publish-poll timeout are not lost.
- **Add debug visibility**: Insert "Show effective POM" steps in both publish jobs to log resolved central-publishing configuration (waitUntil/waitMaxTime) for troubleshooting.
- **Upgrade pitest**: Bump pitest-maven from 1.25.5 to 1.25.6.

## Test plan

- CI is green on this branch
- Existing publish workflow tests (if any) pass
- Manual verification: Confirm that `github-snapshot` and `github-release` jobs execute and attach artifacts even if `publish-snapshot` or `publish-release` fail due to Central timeout

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_018e3Pk8a2yzmrmNb2DEw9JS