### PR TITLE
Upgrade gradle/actions/setup-gradle to v6 and pitest-maven to 1.25.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
         with:
           java-version: '21'
           distribution: temurin
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.14.3"
       - name: Sign a throwaway artifact via useInMemoryPgpKeys (BouncyCastle)

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.6</version>
+                    <version>1.25.7</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
## Summary

- Upgrade `gradle/actions/setup-gradle` GitHub Action from v4 to v6
- Upgrade `pitest-maven` plugin from 1.25.6 to 1.25.7

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01EDGkPGwehc22JjeKFUfgyk