### PR TITLE
Upgrade palantir-java-format to 2.96.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         <jspecify.version>1.0.0</jspecify.version>
         <checker.version>4.2.1</checker.version>
         <spotless.version>3.8.0</spotless.version>
-        <palantir-java-format.version>2.94.0</palantir-java-format.version>
+        <palantir-java-format.version>2.96.0</palantir-java-format.version>
         <spotbugs.version>4.10.3.0</spotbugs.version>
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>


### PR DESCRIPTION
## Summary

- Upgrade `palantir-java-format` dependency from 2.94.0 to 2.96.0
- This is a minor version bump that includes bug fixes and improvements to the Java code formatter

## Test plan

- [x] CI is green on this branch
- [x] No source code changes required — dependency upgrade only

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01RzKLo5MC4n1PJsq5zeW7dP