### PR TITLE
Upgrade NullAway from 0.13.7 to 0.13.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
              section "jqwik prompt-injection in test output" for full context. -->
         <jqwik.version>1.9.3</jqwik.version>
         <errorprone.version>2.50.0</errorprone.version>
-        <nullaway.version>0.13.7</nullaway.version>
+        <nullaway.version>0.13.8</nullaway.version>
         <jspecify.version>1.0.0</jspecify.version>
         <checker.version>4.2.1</checker.version>
         <spotless.version>3.8.0</spotless.version>


### PR DESCRIPTION
## Summary

- Bump NullAway dependency from 0.13.7 to 0.13.8 to pick up the latest bug fixes and improvements from the NullAway project.

## Test plan

- [x] CI is green on this branch (dependency upgrade only, no code changes)

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_015eEnMyvPF95KxPUsPtF5BW