### PR TITLE
ci: unify signing-selftest SPDX (byte-identical cross-repo) + add LICENSES/MIT.txt

### DIFF
--- a/.github/signing-selftest/build.gradle.kts
+++ b/.github/signing-selftest/build.gradle.kts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 // Throwaway signing project used ONLY by the `verify-signing-key-gradle`
 // preflight job in .github/workflows/publish.yml. It signs a tiny throwaway Zip

--- a/.github/signing-selftest/settings.gradle.kts
+++ b/.github/signing-selftest/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 rootProject.name = "signing-selftest"

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary

- **Unify `.github/signing-selftest/`** (`build.gradle.kts` + `settings.gradle.kts`) to the dual `MIT OR Apache-2.0` SPDX header so the throwaway `verify-signing-key-gradle` project is truly byte-identical across all four sibling repos (previously the body matched but the SPDX header drifted per repo).
- **Add `LICENSES/MIT.txt`** (streambuffer previously shipped only `Apache-2.0.txt`) so the dual identifier is REUSE-compliant.

CI-config only — no production code changes; streambuffer has no fat jar / Lombok, so those parts of the cross-repo pass don't apply here.

## Test plan

- [x] No source changes; library behavior unaffected
- [ ] CI green on this branch (incl. REUSE check with the added MIT.txt)
- [x] N/A — docs/CHANGELOG (config-only)

## Related issues / PRs

Coordinated cross-repo change; the canonical docs + the checksum drift-check table land in the **workspace** PR (same branch name). Sibling PRs: java-llama.cpp / BitcoinAddressFinder / srcmorph / workspace.

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJzCezSnQ8FxpFdeVxYxQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJzCezSnQ8FxpFdeVxYxQY)_