### PR TITLE
Upgrade spotless to 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
         <nullaway.version>0.13.8</nullaway.version>
         <jspecify.version>1.0.0</jspecify.version>
         <checker.version>4.2.1</checker.version>
-        <spotless.version>3.8.0</spotless.version>
+        <spotless.version>3.9.0</spotless.version>
         <palantir-java-format.version>2.96.0</palantir-java-format.version>
         <spotbugs.version>4.10.3.0</spotbugs.version>
         <fb-contrib.version>7.7.4</fb-contrib.version>


### PR DESCRIPTION
## Summary

- Upgrade spotless Maven plugin from 3.8.0 to 3.9.0

## Test plan

- [ ] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01Ap1143gp7CRatgo9TezNhQ