### PR TITLE
Add dependency convergence pinning for jspecify and hamcrest

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.183
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.183
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,14 @@ thing keeping it clear of the JPMS module-mode javadoc trap that bit BAF. **Befo
 Java / javadoc source level to ≥ 9, read**
 [`../workspace/policies/jpms-module-descriptor.md`](../workspace/policies/jpms-module-descriptor.md).
 
+## Dependency Convergence Pinning
+
+`dependencyConvergence` is enabled (maven-enforcer). This repo has no parent POM, so its
+`dependencyManagement` block (pinning `jspecify`/`hamcrest`) is the repo's only convergence
+backstop — added because it previously had none. Convention + the `excludedScopes=[test,provided]`
+enforcer default gotcha are in
+[`../workspace/policies/dependency-convergence-pinning.md`](../workspace/policies/dependency-convergence-pinning.md).
+
 ## Open TODOs
 
 Open TODOs for this repo live in [`TODO.md`](TODO.md). Cross-repo status

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.8</version>
+                    <version>1.25.9</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>8</java.version>
         <java.test.version>21</java.test.version>
-        <junit.version>6.1.2</junit.version>
+        <junit.version>6.1.3</junit.version>
         <hamcrest.version>3.0</hamcrest.version>
         <jmh.version>1.37</jmh.version>
         <jcstress.version>0.16</jcstress.version>
@@ -33,13 +33,13 @@ SPDX-License-Identifier: Apache-2.0
         <errorprone.version>2.50.0</errorprone.version>
         <nullaway.version>0.13.8</nullaway.version>
         <jspecify.version>1.0.1</jspecify.version>
-        <checker.version>4.2.1</checker.version>
+        <checker.version>4.2.2</checker.version>
         <spotless.version>3.9.0</spotless.version>
         <palantir-java-format.version>2.96.0</palantir-java-format.version>
         <spotbugs.version>4.10.3.0</spotbugs.version>
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>
-        <archunit.version>1.4.2</archunit.version>
+        <archunit.version>1.5.0</archunit.version>
         <awaitility.version>4.3.0</awaitility.version>
         <concurrentunit.version>0.4.6</concurrentunit.version>
         <lincheck.version>3.7</lincheck.version>
@@ -94,6 +94,36 @@ SPDX-License-Identifier: Apache-2.0
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
+    <!--
+        This repo has no parent POM and previously had no <dependencyManagement> at all, so
+        maven-enforcer's <dependencyConvergence/> rule (bound in the enforcer-maven execution
+        below) had nothing to fall back on if a direct declaration and a transitive request of the
+        same artifact ever diverged. Both pins below are currently invisible to the rule anyway:
+        DependencyConvergence excludes test/provided scope by default (verified against
+        enforcer-rules 3.6.3), and both conflicting transitive requests are test-scoped — so today
+        this is a defensive pin against a scope quirk, not a fix for an active failure. See
+        BitcoinAddressFinder's pom.xml for the sibling repo where the same jspecify mismatch was
+        compile-scoped and did fail CI.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <!-- jspecify: org.junit.jupiter:junit-jupiter (junit-jupiter-api/-params/-engine,
+                 junit-platform-commons/-engine, all test scope) brings 1.0.0; we declare
+                 ${jspecify.version} directly. -->
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
+            </dependency>
+            <!-- hamcrest: org.awaitility:awaitility (test scope) brings 2.1; we declare
+                 ${hamcrest.version} directly. -->
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <!-- Annotation-only deps below are marked <optional>true</optional> so they
              do NOT propagate onto downstream consumers' runtime classpaths. The


### PR DESCRIPTION
## Summary

- Add `<dependencyManagement>` block to pin `jspecify` and `hamcrest` versions, preventing transitive dependency convergence failures from test-scoped conflicts
- Document the dependency convergence pinning strategy in `CLAUDE.md`
- Update build tool versions: JUnit 6.1.3, Checker Framework 4.2.2, ArchUnit 1.5.0, PIT 1.25.9
- Update Claude Code action to use stable `v1` tag instead of pinned version

## Test plan

- [x] CI is green on this branch
- [x] Docs updated (`CLAUDE.md`)

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01KqVypnKbydSNgmGFfhCMUc